### PR TITLE
Added average damage to tank-win-rate and win-rate

### DIFF
--- a/bin/bot.js
+++ b/bin/bot.js
@@ -57,10 +57,10 @@ process.title = pkg.name;
 client.rest.userAgentManager.set({url: pkg.homepage, version: pkg.version});
 
 client.on('ready', () => {
-	console.log('blitzbot ready!');
-	console.log('===============');
-	console.error('blitzbot ready!');
-	console.error('===============');
+	helpers.log('blitzbot ready!');
+	helpers.log('===============');
+	helpers.error('blitzbot ready!');
+	helpers.error('===============');
 });
 
 client.on('message', message => {
@@ -73,7 +73,8 @@ client.on('message', message => {
 	if (!perms) return;
 
 	const userId = message.author.id;
-	const id = message.id + ', ' + userId;
+	const userName = message.author.username;
+	const id = 'msgId: ' + message.id + ', userId: ' + userId + ', userName: ' + userName;
 	const mention = client.user.toString() + ' ';
 	const text = message.content.replace(/\s{2,}/g, ' ');
 	const m = text.match(/^[\t ]*\b(n|na|e|eu|r|ru|a|asia)\b/i);
@@ -126,7 +127,7 @@ client.on('message', message => {
 
 		let run;
 
-		console.log(id + ' -- running command: "' + command + '"');
+		helpers.log(id + ' -- running command: "' + command + '"');
 
 		if (passRecord) {
 			run = new Promise((resolve, reject) => {
@@ -139,7 +140,7 @@ client.on('message', message => {
 					} else {
 						resolve(message.reply('I don\'t know who you are! Do `@' + client.user.username + ' add <screen-name>` first.')
 							.then(sent => {
-								console.log(id + ' -- sent msg: ' + sent);
+								helpers.log(id + ' -- sent msg: ' + sent);
 
 								return null;
 							}));
@@ -154,7 +155,7 @@ client.on('message', message => {
 	}).then(([result, db]) => {
 		if (!result) return;
 
-		console.log(id + ' -- sent msg: ' + helpers.messageToString(result.sentMsg));
+		helpers.log(id + ' -- sent msg: ' + helpers.messageToString(result.sentMsg));
 
 		const update = result.updateFields;
 
@@ -163,7 +164,7 @@ client.on('message', message => {
 			db = master;
 		}
 
-		console.log(id + ' -- update document ' + db.filename);
+		helpers.log(id + ' -- update document ' + db.filename);
 
 		// add '_id' and remove 'updatedAt' so that upserting works every time, safely.
 		update._id = userId;
@@ -176,13 +177,13 @@ client.on('message', message => {
 			});
 		});
 	}).then(() => {
-		console.log(id + ' -- done: ' + command);
+		helpers.log(id + ' -- done: ' + command);
 	}).catch(error => {
-		console.error(id + ' -- error: ' + command);
+		helpers.error(id + ' -- error: ' + command);
 
-		if (!error) return console.log(id + ' -- error: Unknown');
+		if (!error) return helpers.log(id + ' -- error: Unknown');
 
-		console.error(helpers.getFieldByPath(error, 'response.error.text') || error.stack || error);
+		helpers.error(helpers.getFieldByPath(error, 'response.error.text') || error.stack || error);
 	});
 });
 
@@ -205,8 +206,8 @@ Promise.all([
 ]).then(() => {
 	// not using a promise because this server is event based, not assuming any event occurs only once
 	serveReferences(Object.assign({bot: client}, regions), 8008, serverErr => {
-		if (serverErr) return console.error(serverErr.stack || serverErr);
+		if (serverErr) return helpers.error(serverErr.stack || serverErr);
 	});
 }, error => {
-	console.error(helpers.getFieldByPath(error, 'response.error.text') || error.stack || error);
+	helpers.error(helpers.getFieldByPath(error, 'response.error.text') || error.stack || error);
 });

--- a/bin/bot.js
+++ b/bin/bot.js
@@ -57,10 +57,10 @@ process.title = pkg.name;
 client.rest.userAgentManager.set({url: pkg.homepage, version: pkg.version});
 
 client.on('ready', () => {
-	helpers.log('blitzbot ready!');
-	helpers.log('===============');
-	helpers.error('blitzbot ready!');
-	helpers.error('===============');
+	log('blitzbot ready!');
+	log('===============');
+	error('blitzbot ready!');
+	error('===============');
 });
 
 client.on('message', message => {
@@ -73,8 +73,7 @@ client.on('message', message => {
 	if (!perms) return;
 
 	const userId = message.author.id;
-	const userName = message.author.username;
-	const id = 'msgId: ' + message.id + ', userId: ' + userId + ', userName: ' + userName;
+	const id = 'msgId: ' + message.id + ', userId: ' + userId;
 	const mention = client.user.toString() + ' ';
 	const text = message.content.replace(/\s{2,}/g, ' ');
 	const m = text.match(/^[\t ]*\b(n|na|e|eu|r|ru|a|asia)\b/i);
@@ -127,7 +126,7 @@ client.on('message', message => {
 
 		let run;
 
-		helpers.log(id + ' -- running command: "' + command + '"');
+		log(id + ' -- running command: "' + command + '"');
 
 		if (passRecord) {
 			run = new Promise((resolve, reject) => {
@@ -140,7 +139,7 @@ client.on('message', message => {
 					} else {
 						resolve(message.reply('I don\'t know who you are! Do `@' + client.user.username + ' add <screen-name>` first.')
 							.then(sent => {
-								helpers.log(id + ' -- sent msg: ' + sent);
+								log(id + ' -- sent msg: ' + sent);
 
 								return null;
 							}));
@@ -155,7 +154,7 @@ client.on('message', message => {
 	}).then(([result, db]) => {
 		if (!result) return;
 
-		helpers.log(id + ' -- sent msg: ' + helpers.messageToString(result.sentMsg));
+		log(id + ' -- sent msg: ' + helpers.messageToString(result.sentMsg));
 
 		const update = result.updateFields;
 
@@ -164,7 +163,7 @@ client.on('message', message => {
 			db = master;
 		}
 
-		helpers.log(id + ' -- update document ' + db.filename);
+		log(id + ' -- update document ' + db.filename);
 
 		// add '_id' and remove 'updatedAt' so that upserting works every time, safely.
 		update._id = userId;
@@ -177,13 +176,13 @@ client.on('message', message => {
 			});
 		});
 	}).then(() => {
-		helpers.log(id + ' -- done: ' + command);
+		log(id + ' -- done: ' + command);
 	}).catch(error => {
-		helpers.error(id + ' -- error: ' + command);
+		error(id + ' -- error: ' + command);
 
-		if (!error) return helpers.log(id + ' -- error: Unknown');
+		if (!error) return log(id + ' -- error: Unknown');
 
-		helpers.error(helpers.getFieldByPath(error, 'response.error.text') || error.stack || error);
+		error(helpers.getFieldByPath(error, 'response.error.text') || error.stack || error);
 	});
 });
 
@@ -206,8 +205,28 @@ Promise.all([
 ]).then(() => {
 	// not using a promise because this server is event based, not assuming any event occurs only once
 	serveReferences(Object.assign({bot: client}, regions), 8008, serverErr => {
-		if (serverErr) return helpers.error(serverErr.stack || serverErr);
+		if (serverErr) return error(serverErr.stack || serverErr);
 	});
 }, error => {
-	helpers.error(helpers.getFieldByPath(error, 'response.error.text') || error.stack || error);
+	error(helpers.getFieldByPath(error, 'response.error.text') || error.stack || error);
 });
+
+
+/**
+ * Logs a message to the console log with a timestamp prepended to it
+ *
+ * @param {*} message A message of any type
+ */
+function log(message) {
+	console.log(new Date().toLocaleString() + ' ' + helpers.messageToString(message));
+}
+
+
+/**
+ * Logs a message to the console error log with a timestamp prepended to it
+ *
+ * @param {*} message A message of any type
+ */
+function error(message) {
+	console.error(new Date().toLocaleString() + ' ' + helpers.messageToString(message));
+}

--- a/lib/command/maxXp.js
+++ b/lib/command/maxXp.js
@@ -1,4 +1,5 @@
 const {Command} = require('./index.js');
+const helpers = require('../helpers.js');
 const maxXpOptions = {
 	description: 'Get your top 10 *max-xp* values.',
 	passRecord: true,
@@ -20,6 +21,6 @@ function maxXpFn(msg, record) {
 			return this.wotblitz.encyclopedia.vehicles(top10.map(x => x.tank_id), null, ['name', 'tier', 'nation'])
 				.then(vehicles => top10.map(x => Object.assign(x.all, unknownTank, vehicles[x.tank_id])));
 		})
-		.then(data => msg.reply(data.map((d, i) => `${i + 1}, ${d.max_xp} xp: ${d.name} (${d.nation}, ${d.tier})`).join('\n')))
+		.then(data => msg.reply('\n' + data.map((d, i) => `${i + 1}: ${helpers.formatNumber(d.max_xp)} xp - ${d.name} (${d.nation}, ${d.tier})`).join('\n')))
 		.then(sent => ({sentMsg: sent}));
 }

--- a/lib/command/winRate.js
+++ b/lib/command/winRate.js
@@ -27,7 +27,8 @@ const winRateCmd = new Command(wrFn, wrOptions, 'win-rate');
 
 module.exports = {
 	tankWinRate: tankWinRateCmd,
-	winRate: winRateCmd
+	winRate: winRateCmd,
+	formatNumber: formatNumber
 };
 
 function twrFn(msg, authorRecord, tankName) {
@@ -83,7 +84,7 @@ function twrFn(msg, authorRecord, tankName) {
 						const avgDmg = stat.all.damage_dealt / stat.all.battles;
 
 						return tankopedia.name + ' (' + tankopedia.nation + ', ' + tankopedia.tier + '): ' +
-							winRate.toFixed(2) + '%, ' + avgDmg.toFixed(2) + ' dmg after ' + stat.all.battles + ' battles.';
+							winRate.toFixed(2) + '%, ' + formatNumber(avgDmg) + ' damage after ' + stat.all.battles + ' battles.';
 					});
 
 					return msg.reply(lines.join('\n'), {split: true}).then(sent => {
@@ -104,26 +105,25 @@ function wrFn(msg, record) {
 
 			let percent = (wins / battles) * 100;
 			let avgDmg = damage / battles;
-			let send = `You have won ${wins} of ${battles} battles. That is ${percent.toFixed(2)}% victory! Your average damage is ${avgDmg.toFixed(2)}.`;
+			let send = `You have won ${formatNumber(wins)} of ${formatNumber(battles)} battles. That is ${percent.toFixed(2)}% victory! Your average damage is ${formatNumber(avgDmg)}.`;
 
 			if (record.wins && record.battles && battles - record.battles > 0) {
 				percent = (record.wins / record.battles) * 100;
-				send += `\nLast time you asked was ${battles - record.battles} battles ago, at ${percent.toFixed(2)}% victory`;
+				send += `\nLast time you asked was ${formatNumber(battles - record.battles)} battles ago, at ${percent.toFixed(2)}% victory`;
 
 				// Only print out previous damage if we've recorded it
 				if (record.damage) {
 					avgDmg = record.damage / record.battles;
-					send += ` and ${avgDmg.toFixed(2)} average damage dealt.`;
-				} else {
-					send += `.`;
+					send += ` and ${formatNumber(avgDmg)} average damage dealt`;
 				}
+				send += `.`;
 
 				percent = ((wins - record.wins) / (battles - record.battles)) * 100;
-				avgDmg = ((damage - record.damage) / (battles - record.battles));
-				send += `\nOver those ${battles - record.battles} battles, you won ${percent.toFixed(2)}%`;
+				avgDmg = (damage - record.damage) / (battles - record.battles);
+				send += `\nOver those ${formatNumber(battles - record.battles)} battles, you won ${percent.toFixed(2)}%`;
 
 				if (avgDmg) {
-					send += ` with average damage of ${avgDmg.toFixed(2)}`;
+					send += ` with average damage of ${formatNumber(avgDmg)}`;
 				}
 				send += `!`;
 			}
@@ -142,4 +142,24 @@ function wrFn(msg, record) {
 				return result;
 			});
 		});
+}
+
+/**
+ * Formats a number to the following specification:
+ * - Whole numbers have no decimal point
+ * - No trailing zeros
+ * - Max of two fraction digits
+ * - American English grouping and decimal separators are used (comma for thousands and period for
+ *   the decimal)
+ *
+ * Examples:
+ * 100 -> 100
+ * 2.789 -> 2.79
+ * 2000 -> 2,000
+ * 4582000.55000 -> 4,582,000.55
+ * 25.000000001 -> 25
+ */
+const format = new Intl.NumberFormat( 'en-US', { minimumFractionDigits: 0, maximumFractionDigits: 2 });
+function formatNumber(numStr) {
+	return format.format(numStr);
 }

--- a/lib/command/winRate.js
+++ b/lib/command/winRate.js
@@ -68,7 +68,7 @@ function twrFn(msg, authorRecord, tankName) {
 				});
 			}
 
-			return this.wotblitz.tanks.stats(record.account_id, null, tankIds, null, ['tank_id', 'all.battles', 'all.wins'])
+			return this.wotblitz.tanks.stats(record.account_id, null, tankIds, null, ['tank_id', 'all.battles', 'all.wins', 'all.damage_dealt'])
 				.then(stats => {
 					// tank stats does *not* error when tank_id has no information
 					if (!stats[record.account_id]) {
@@ -80,9 +80,10 @@ function twrFn(msg, authorRecord, tankName) {
 					const lines = stats[record.account_id].map(stat => {
 						const tankopedia = vehicles[stat.tank_id];
 						const winRate = (stat.all.wins / stat.all.battles) * 100;
+						const avgDmg = stat.all.damage_dealt / stat.all.battles;
 
 						return tankopedia.name + ' (' + tankopedia.nation + ', ' + tankopedia.tier + '): ' +
-							winRate.toFixed(2) + '%' + ' after ' + stat.all.battles + ' battles.';
+							winRate.toFixed(2) + '%, ' + avgDmg.toFixed(2) + ' dmg after ' + stat.all.battles + ' battles.';
 					});
 
 					return msg.reply(lines.join('\n'), {split: true}).then(sent => {
@@ -94,27 +95,44 @@ function twrFn(msg, authorRecord, tankName) {
 }
 
 function wrFn(msg, record) {
-	return this.wotblitz.account.info(record.account_id, null, null, ['statistics.all.battles', 'statistics.all.wins'])
+	return this.wotblitz.account.info(record.account_id, null, null, ['statistics.all.battles', 'statistics.all.wins', 'statistics.all.damage_dealt'])
 		.then(info => {
 			const wins = info[record.account_id].statistics.all.wins;
 			const battles = info[record.account_id].statistics.all.battles;
+			const damage = info[record.account_id].statistics.all.damage_dealt;
 			const result = {};
 
 			let percent = (wins / battles) * 100;
-			let send = `You have won ${wins} of ${battles} battles. That is ${percent.toFixed(2)}% victory!`;
+			let avgDmg = damage / battles;
+			let send = `You have won ${wins} of ${battles} battles. That is ${percent.toFixed(2)}% victory! Your average damage is ${avgDmg.toFixed(2)}.`;
 
 			if (record.wins && record.battles && battles - record.battles > 0) {
 				percent = (record.wins / record.battles) * 100;
-				send += `\nLast time you asked was ${battles - record.battles} battles ago, at ${percent.toFixed(2)}% victory.`;
+				send += `\nLast time you asked was ${battles - record.battles} battles ago, at ${percent.toFixed(2)}% victory`;
+
+				// Only print out previous damage if we've recorded it
+				if (record.damage) {
+					avgDmg = record.damage / record.battles;
+					send += ` and ${avgDmg.toFixed(2)} average damage dealt.`;
+				} else {
+					send += `.`;
+				}
 
 				percent = ((wins - record.wins) / (battles - record.battles)) * 100;
-				send += `\nOver those ${battles - record.battles} battles, you won ${percent.toFixed(2)}%!`;
+				avgDmg = ((damage - record.damage) / (battles - record.battles));
+				send += `\nOver those ${battles - record.battles} battles, you won ${percent.toFixed(2)}%`;
+
+				if (avgDmg) {
+					send += ` with average damage of ${avgDmg.toFixed(2)}`;
+				}
+				send += `!`;
 			}
 
 			if (!record.battles || battles - record.battles > 0) {
 				result.updateFields = {
 					wins: wins,
-					battles: battles
+					battles: battles,
+					damage: damage
 				};
 			}
 

--- a/lib/command/winRate.js
+++ b/lib/command/winRate.js
@@ -1,5 +1,6 @@
 const {Command} = require('./index.js');
 const rmAccents = require('remove-accents');
+const helpers = require('../helpers.js');
 const MAX_TANK_ID_COUNT = 100;
 const twrOptions = {
 	alias: 'twr',
@@ -27,8 +28,7 @@ const winRateCmd = new Command(wrFn, wrOptions, 'win-rate');
 
 module.exports = {
 	tankWinRate: tankWinRateCmd,
-	winRate: winRateCmd,
-	formatNumber: formatNumber
+	winRate: winRateCmd
 };
 
 function twrFn(msg, authorRecord, tankName) {
@@ -84,7 +84,7 @@ function twrFn(msg, authorRecord, tankName) {
 						const avgDmg = stat.all.damage_dealt / stat.all.battles;
 
 						return tankopedia.name + ' (' + tankopedia.nation + ', ' + tankopedia.tier + '): ' +
-							winRate.toFixed(2) + '%, ' + formatNumber(avgDmg) + ' damage after ' + stat.all.battles + ' battles.';
+							winRate.toFixed(2) + '%, ' + helpers.formatNumber(avgDmg) + ' damage after ' + stat.all.battles + ' battles.';
 					});
 
 					return msg.reply(lines.join('\n'), {split: true}).then(sent => {
@@ -105,25 +105,25 @@ function wrFn(msg, record) {
 
 			let percent = (wins / battles) * 100;
 			let avgDmg = damage / battles;
-			let send = `You have won ${formatNumber(wins)} of ${formatNumber(battles)} battles. That is ${percent.toFixed(2)}% victory! Your average damage is ${formatNumber(avgDmg)}.`;
+			let send = `You have won ${helpers.formatNumber(wins)} of ${helpers.formatNumber(battles)} battles. That is ${percent.toFixed(2)}% victory! Your average damage is ${helpers.formatNumber(avgDmg)}.`;
 
 			if (record.wins && record.battles && battles - record.battles > 0) {
 				percent = (record.wins / record.battles) * 100;
-				send += `\nLast time you asked was ${formatNumber(battles - record.battles)} battles ago, at ${percent.toFixed(2)}% victory`;
+				send += `\nLast time you asked was ${helpers.formatNumber(battles - record.battles)} battles ago, at ${percent.toFixed(2)}% victory`;
 
 				// Only print out previous damage if we've recorded it
 				if (record.damage) {
 					avgDmg = record.damage / record.battles;
-					send += ` and ${formatNumber(avgDmg)} average damage dealt`;
+					send += ` and ${helpers.formatNumber(avgDmg)} average damage dealt`;
 				}
 				send += `.`;
 
 				percent = ((wins - record.wins) / (battles - record.battles)) * 100;
 				avgDmg = (damage - record.damage) / (battles - record.battles);
-				send += `\nOver those ${formatNumber(battles - record.battles)} battles, you won ${percent.toFixed(2)}%`;
+				send += `\nOver those ${helpers.formatNumber(battles - record.battles)} battles, you won ${percent.toFixed(2)}%`;
 
 				if (avgDmg) {
-					send += ` with average damage of ${formatNumber(avgDmg)}`;
+					send += ` with average damage of ${helpers.formatNumber(avgDmg)}`;
 				}
 				send += `!`;
 			}
@@ -142,24 +142,4 @@ function wrFn(msg, record) {
 				return result;
 			});
 		});
-}
-
-/**
- * Formats a number to the following specification:
- * - Whole numbers have no decimal point
- * - No trailing zeros
- * - Max of two fraction digits
- * - American English grouping and decimal separators are used (comma for thousands and period for
- *   the decimal)
- *
- * Examples:
- * 100 -> 100
- * 2.789 -> 2.79
- * 2000 -> 2,000
- * 4582000.55000 -> 4,582,000.55
- * 25.000000001 -> 25
- */
-const format = new Intl.NumberFormat( 'en-US', { minimumFractionDigits: 0, maximumFractionDigits: 2 });
-function formatNumber(numStr) {
-	return format.format(numStr);
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,6 +1,7 @@
 module.exports = {
 	getFieldByPath: getFieldByPath,
 	messageToString: messageToString,
+	formatNumber: formatNumber,
 	log: log,
 	error: error,
 	sortBy: sortBy
@@ -85,6 +86,26 @@ function messageToString(message) {
 	}
 
 	return message.toString();
+}
+
+/**
+ * Formats a number to the following specification:
+ * - Whole numbers have no decimal point
+ * - No trailing zeros
+ * - Max of two fraction digits
+ * - American English grouping and decimal separators are used (comma for thousands and period for
+ *   the decimal)
+ *
+ * Examples:
+ * 100 -> 100
+ * 2.789 -> 2.79
+ * 2000 -> 2,000
+ * 4582000.55000 -> 4,582,000.55
+ * 25.000000001 -> 25
+ */
+const format = new Intl.NumberFormat( 'en-US', { minimumFractionDigits: 0, maximumFractionDigits: 2 });
+function formatNumber(numStr) {
+	return format.format(numStr);
 }
 
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,6 +1,8 @@
 module.exports = {
 	getFieldByPath: getFieldByPath,
 	messageToString: messageToString,
+	log: log,
+	error: error,
 	sortBy: sortBy
 };
 
@@ -84,3 +86,27 @@ function messageToString(message) {
 
 	return message.toString();
 }
+
+
+/**
+ * Logs a message to the console log with a timestamp prepended to it
+ *
+ * @param {*} message A message of any type
+ */
+function log(message) {
+	console.log(new Date().toLocaleString() + ' ' + messageToString(message));
+}
+
+
+
+/**
+ * Logs a message to the console error log with a timestamp prepended to it
+ *
+ * @param {*} message A message of any type
+ */
+function error(message) {
+	console.error(new Date().toLocaleString() + ' ' + messageToString(message));
+}
+
+
+

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -2,8 +2,6 @@ module.exports = {
 	getFieldByPath: getFieldByPath,
 	messageToString: messageToString,
 	formatNumber: formatNumber,
-	log: log,
-	error: error,
 	sortBy: sortBy
 };
 
@@ -106,27 +104,6 @@ function messageToString(message) {
 const format = new Intl.NumberFormat( 'en-US', { minimumFractionDigits: 0, maximumFractionDigits: 2 });
 function formatNumber(numStr) {
 	return format.format(numStr);
-}
-
-
-/**
- * Logs a message to the console log with a timestamp prepended to it
- *
- * @param {*} message A message of any type
- */
-function log(message) {
-	console.log(new Date().toLocaleString() + ' ' + messageToString(message));
-}
-
-
-
-/**
- * Logs a message to the console error log with a timestamp prepended to it
- *
- * @param {*} message A message of any type
- */
-function error(message) {
-	console.error(new Date().toLocaleString() + ' ' + messageToString(message));
 }
 
 

--- a/test/lib.command.maxXp.js
+++ b/test/lib.command.maxXp.js
@@ -158,16 +158,17 @@ test('command.maxXp', t => {
 			});
 		const expected = {
 			sentMsg: [
-				'@SillyGamer5, 1, 1844 xp: Cromwell (uk, 6)',
-				'2, 1794 xp: T-44 (ussr, 8)',
-				'3, 1551 xp: T1 Heavy (usa, 5)',
-				'4, 1549 xp: Jagdpanther (germany, 7)',
-				'5, 1518 xp: Type 62 (china, 7)',
-				'6, 1486 xp: Type 5 Ke-Ho (japan, 4)',
-				'7, 1457 xp: Leopard (germany, 5)',
-				'8, 1422 xp: KV-13 (ussr, 7)',
-				'9, 1335 xp: M3 Lee (usa, 4)',
-				'10, 900 xp: Cruiser Mk. III (uk, 2)'
+				'@SillyGamer5, ',
+				'1: 1,844 xp - Cromwell (uk, 6)',
+				'2: 1,794 xp - T-44 (ussr, 8)',
+				'3: 1,551 xp - T1 Heavy (usa, 5)',
+				'4: 1,549 xp - Jagdpanther (germany, 7)',
+				'5: 1,518 xp - Type 62 (china, 7)',
+				'6: 1,486 xp - Type 5 Ke-Ho (japan, 4)',
+				'7: 1,457 xp - Leopard (germany, 5)',
+				'8: 1,422 xp - KV-13 (ussr, 7)',
+				'9: 1,335 xp - M3 Lee (usa, 4)',
+				'10: 900 xp - Cruiser Mk. III (uk, 2)'
 			].join('\n')
 		};
 
@@ -245,9 +246,10 @@ test('command.maxXp', t => {
 			});
 		const expected = {
 			sentMsg: [
-				'@BigTanks, 1, 901 xp: M2 Medium (us, 3)',
-				'2, 892 xp: Unknown vehicle (-, -)',
-				'3, 884 xp: T2 Medium (us, 2)'
+				'@BigTanks, ',
+				'1: 901 xp - M2 Medium (us, 3)',
+				'2: 892 xp - Unknown vehicle (-, -)',
+				'3: 884 xp - T2 Medium (us, 2)'
 			].join('\n')
 		};
 

--- a/test/lib.command.winRate.js
+++ b/test/lib.command.winRate.js
@@ -11,6 +11,15 @@ const dbInstance = new Datastore({
 });
 const callTankWinRate = wr.tankWinRate.fn.bind(Object.assign(mocks.commands, {db: dbInstance}));
 const callWinRate = wr.winRate.fn.bind(mocks.commands);
+const callFormatNumber = wr.formatNumber;
+
+test('numberFormat', t => {
+	t.equal(callFormatNumber(1500), '1,500');
+	t.equal(callFormatNumber(26522.56723), '26,522.57');
+	t.equal(callFormatNumber(340.500), '340.5');
+	t.equal(callFormatNumber(2362244.0000000000002), '2,362,244');
+	t.end();
+});
 
 test('command.winRate.tankWinRate', t => {
 	t.deepEqual(wr.tankWinRate.fn.options, {
@@ -140,7 +149,7 @@ test('command.winRate.tankWinRate', t => {
 
 		callTankWinRate(mocks.createMessage(null, 'hulkhogan [CL]', []), {account_id: 100998144}, 'Löwe').then(result => {
 			st.deepEqual(result, {
-				sentMsg: '@hulkhogan [CL], Löwe (germany, 8): 56.18%, 100.00 dmg after 283 battles.'
+				sentMsg: '@hulkhogan [CL], Löwe (germany, 8): 56.18%, 100 damage after 283 battles.'
 			}, 'verify response');
 
 			st.ok(tankopediaVehicles.isDone() && tankStats.isDone(), 'make two api calls');
@@ -190,8 +199,8 @@ test('command.winRate.tankWinRate', t => {
 		callTankWinRate(mocks.createMessage(null, 'jessie5 [CL]', []), {account_id: 100998145}, 'Pershing').then(result => {
 			st.deepEqual(result, {
 				sentMsg: [
-					'@jessie5 [CL], M26 Pershing (usa, 8): 71.72%, 1872.66 dmg after 534 battles.',
-					'T26E4 SuperPershing (usa, 8): 52.70%, 1351.35 dmg after 74 battles.'
+					'@jessie5 [CL], M26 Pershing (usa, 8): 71.72%, 1,872.66 damage after 534 battles.',
+					'T26E4 SuperPershing (usa, 8): 52.70%, 1,351.35 damage after 74 battles.'
 				].join('\n')
 			}, 'verify response');
 
@@ -233,7 +242,7 @@ test('command.winRate.tankWinRate', t => {
 			});
 
 		callTankWinRate(mocks.createMessage(null, 'statdude [STAT]', []), {account_id: 100996799}, 'Lowe').then(result => {
-			st.deepEqual(result, {sentMsg: '@statdude [STAT], Löwe (germany, 8): 57.14%, 892.86 dmg after 112 battles.'}, 'verify response');
+			st.deepEqual(result, {sentMsg: '@statdude [STAT], Löwe (germany, 8): 57.14%, 892.86 damage after 112 battles.'}, 'verify response');
 			st.ok(tankopediaVehicles.isDone() && tankStats.isDone(), 'made two api calls');
 			st.end();
 		}, error => {
@@ -345,7 +354,7 @@ test('command.winRate.tankWinRate', t => {
 			callTankWinRate(mocks.createMessage(null, 'iambesttanker [CL]', mentions), {account_id: 100998148}, 'Tiger I')
 				.then(result => {
 					st.deepEqual(result, {
-						sentMsg: '@iambesttanker [CL], Tiger I (germany, 7): 53.30%, 1321.59 dmg after 227 battles.'
+						sentMsg: '@iambesttanker [CL], Tiger I (germany, 7): 53.30%, 1,321.59 damage after 227 battles.'
 					}, 'verify response');
 					st.ok(tankopediaVehicles.isDone() && tankStats.isDone(), 'make two api calls');
 					st.end();
@@ -410,7 +419,7 @@ test('command.winRate.winRate', t => {
 			account_id: 100994563
 		}).then(result => {
 			st.deepEqual(result, {
-				sentMsg: '@bigguy20 [CL], You have won 8691 of 14280 battles. That is 60.86% victory! Your average damage is 1423.00.',
+				sentMsg: '@bigguy20 [CL], You have won 8,691 of 14,280 battles. That is 60.86% victory! Your average damage is 1,423.',
 				updateFields: {
 					wins: 8691,
 					battles: 14280,
@@ -435,7 +444,7 @@ test('command.winRate.winRate', t => {
 			battles: 18290
 		}).then(result => {
 			st.deepEqual(result, {
-				sentMsg: '@littleguy21 [CL], You have won 7682 of 18290 battles. That is 42.00% victory! Your average damage is 1000.00.'
+				sentMsg: '@littleguy21 [CL], You have won 7,682 of 18,290 battles. That is 42.00% victory! Your average damage is 1,000.'
 			}, 'verify response');
 
 			st.ok(accountInfo.isDone(), 'made one API call');
@@ -457,9 +466,9 @@ test('command.winRate.winRate', t => {
 		}).then(result => {
 			st.deepEqual(result, {
 				sentMsg: [
-					'@biggirl22 [CL], You have won 9260 of 13933 battles. That is 66.46% victory! Your average damage is 1000.00.',
+					'@biggirl22 [CL], You have won 9,260 of 13,933 battles. That is 66.46% victory! Your average damage is 1,000.',
 					'Last time you asked was 1 battles ago, at 66.46% victory and 999.94 average damage dealt.',
-					'Over those 1 battles, you won 100.00% with average damage of 1836.00!'
+					'Over those 1 battles, you won 100.00% with average damage of 1,836!'
 				].join('\n'),
 				updateFields: {
 					wins: 9260,
@@ -487,7 +496,7 @@ test('command.winRate.winRate', t => {
 		}).then(result => {
 			st.deepEqual(result, {
 				sentMsg: [
-					'@littlegirl23 [CL], You have won 5003 of 11502 battles. That is 43.50% victory! Your average damage is 855.21.',
+					'@littlegirl23 [CL], You have won 5,003 of 11,502 battles. That is 43.50% victory! Your average damage is 855.21.',
 					'Last time you asked was 19 battles ago, at 43.47% victory and 855.38 average damage dealt.',
 					'Over those 19 battles, you won 57.89% with average damage of 755.21!'
 				].join('\n'),
@@ -516,7 +525,7 @@ test('command.winRate.winRate', t => {
 		}).then(result => {
 			st.deepEqual(result, {
 				sentMsg: [
-					'@tankgrl [CL], You have won 5000 of 11501 battles. That is 43.47% victory! Your average damage is 1000.00.',
+					'@tankgrl [CL], You have won 5,000 of 11,501 battles. That is 43.47% victory! Your average damage is 1,000.',
 					'Last time you asked was 18 battles ago, at 43.47% victory.',
 					'Over those 18 battles, you won 44.44%!'
 				].join('\n'),

--- a/test/lib.command.winRate.js
+++ b/test/lib.command.winRate.js
@@ -80,7 +80,7 @@ test('command.winRate.tankWinRate', t => {
 				access_token: '',
 				account_id: '100998143',
 				application_id: process.env.APPLICATION_ID,
-				fields: 'tank_id,all.battles,all.wins',
+				fields: 'tank_id,all.battles,all.wins,all.damage_dealt',
 				in_garage: '',
 				language: 'en',
 				tank_id: '55073'
@@ -117,7 +117,7 @@ test('command.winRate.tankWinRate', t => {
 				account_id: '100998144',
 				application_id: process.env.APPLICATION_ID,
 				in_garage: '',
-				fields: 'tank_id,all.battles,all.wins',
+				fields: 'tank_id,all.battles,all.wins,all.damage_dealt',
 				language: 'en',
 				tank_id: '54289'
 			})
@@ -130,7 +130,8 @@ test('command.winRate.tankWinRate', t => {
 					'100998144': [{
 						all: {
 							battles: 283,
-							wins: 159
+							wins: 159,
+							damage_dealt: 28300
 						},
 						tank_id: 54289
 					}]
@@ -139,7 +140,7 @@ test('command.winRate.tankWinRate', t => {
 
 		callTankWinRate(mocks.createMessage(null, 'hulkhogan [CL]', []), {account_id: 100998144}, 'Löwe').then(result => {
 			st.deepEqual(result, {
-				sentMsg: '@hulkhogan [CL], Löwe (germany, 8): 56.18% after 283 battles.'
+				sentMsg: '@hulkhogan [CL], Löwe (germany, 8): 56.18%, 100.00 dmg after 283 battles.'
 			}, 'verify response');
 
 			st.ok(tankopediaVehicles.isDone() && tankStats.isDone(), 'make two api calls');
@@ -157,7 +158,7 @@ test('command.winRate.tankWinRate', t => {
 				access_token: '',
 				account_id: '100998145',
 				application_id: process.env.APPLICATION_ID,
-				fields: 'tank_id,all.battles,all.wins',
+				fields: 'tank_id,all.battles,all.wins,all.damage_dealt',
 				language: 'en',
 				in_garage: '',
 				tank_id: '5921,13345'
@@ -171,13 +172,15 @@ test('command.winRate.tankWinRate', t => {
 					'100998145': [{
 						all: {
 							battles: 534,
-							wins: 383
+							wins: 383,
+							damage_dealt: 1000000
 						},
 						tank_id: 5921
 					}, {
 						all: {
 							battles: 74,
-							wins: 39
+							wins: 39,
+							damage_dealt: 100000
 						},
 						tank_id: 13345
 					}]
@@ -187,8 +190,8 @@ test('command.winRate.tankWinRate', t => {
 		callTankWinRate(mocks.createMessage(null, 'jessie5 [CL]', []), {account_id: 100998145}, 'Pershing').then(result => {
 			st.deepEqual(result, {
 				sentMsg: [
-					'@jessie5 [CL], M26 Pershing (usa, 8): 71.72% after 534 battles.',
-					'T26E4 SuperPershing (usa, 8): 52.70% after 74 battles.'
+					'@jessie5 [CL], M26 Pershing (usa, 8): 71.72%, 1872.66 dmg after 534 battles.',
+					'T26E4 SuperPershing (usa, 8): 52.70%, 1351.35 dmg after 74 battles.'
 				].join('\n')
 			}, 'verify response');
 
@@ -207,7 +210,7 @@ test('command.winRate.tankWinRate', t => {
 				access_token: '',
 				account_id: '100996799',
 				application_id: process.env.APPLICATION_ID,
-				fields: 'tank_id,all.battles,all.wins',
+				fields: 'tank_id,all.battles,all.wins,all.damage_dealt',
 				in_garage: '',
 				language: 'en',
 				tank_id: '54289'
@@ -221,7 +224,8 @@ test('command.winRate.tankWinRate', t => {
 					'100996799': [{
 						all: {
 							battles: 112,
-							wins: 64
+							wins: 64,
+							damage_dealt: 100000
 						},
 						tank_id: 54289
 					}]
@@ -229,7 +233,7 @@ test('command.winRate.tankWinRate', t => {
 			});
 
 		callTankWinRate(mocks.createMessage(null, 'statdude [STAT]', []), {account_id: 100996799}, 'Lowe').then(result => {
-			st.deepEqual(result, {sentMsg: '@statdude [STAT], Löwe (germany, 8): 57.14% after 112 battles.'}, 'verify response');
+			st.deepEqual(result, {sentMsg: '@statdude [STAT], Löwe (germany, 8): 57.14%, 892.86 dmg after 112 battles.'}, 'verify response');
 			st.ok(tankopediaVehicles.isDone() && tankStats.isDone(), 'made two api calls');
 			st.end();
 		}, error => {
@@ -292,7 +296,7 @@ test('command.winRate.tankWinRate', t => {
 				access_token: '',
 				account_id: '100998149',
 				application_id: process.env.APPLICATION_ID,
-				fields: 'tank_id,all.battles,all.wins',
+				fields: 'tank_id,all.battles,all.wins,all.damage_dealt',
 				in_garage: '',
 				language: 'en',
 				tank_id: '529,5137'
@@ -306,7 +310,8 @@ test('command.winRate.tankWinRate', t => {
 					'100998149': [{
 						all: {
 							battles: 227,
-							wins: 121
+							wins: 121,
+							damage_dealt: 300000
 						},
 						tank_id: 529
 					}]
@@ -340,7 +345,7 @@ test('command.winRate.tankWinRate', t => {
 			callTankWinRate(mocks.createMessage(null, 'iambesttanker [CL]', mentions), {account_id: 100998148}, 'Tiger I')
 				.then(result => {
 					st.deepEqual(result, {
-						sentMsg: '@iambesttanker [CL], Tiger I (germany, 7): 53.30% after 227 battles.'
+						sentMsg: '@iambesttanker [CL], Tiger I (germany, 7): 53.30%, 1321.59 dmg after 227 battles.'
 					}, 'verify response');
 					st.ok(tankopediaVehicles.isDone() && tankStats.isDone(), 'make two api calls');
 					st.end();
@@ -369,14 +374,14 @@ test('command.winRate.winRate', t => {
 
 	t.equal(wr.winRate.name, 'win-rate', 'verify Commands method name');
 
-	const accountInfoMock = (accountId, wins, battles) => {
+	const accountInfoMock = (accountId, wins, battles, damage) => {
 		return nock('https://api.wotblitz.com')
 			.post('/wotb/account/info/', {
 				access_token: '',
 				account_id: accountId.toString(),
 				application_id: process.env.APPLICATION_ID,
 				extra: '',
-				fields: 'statistics.all.battles,statistics.all.wins',
+				fields: 'statistics.all.battles,statistics.all.wins,statistics.all.damage_dealt',
 				language: 'en'
 			})
 			.reply(200, {
@@ -389,7 +394,8 @@ test('command.winRate.winRate', t => {
 						statistics: {
 							all: {
 								battles: battles,
-								wins: wins
+								wins: wins,
+								damage_dealt: damage
 							}
 						}
 					}
@@ -398,16 +404,17 @@ test('command.winRate.winRate', t => {
 	};
 
 	t.test('initial call', st => {
-		const accountInfo = accountInfoMock(100994563, 8691, 14280);
+		const accountInfo = accountInfoMock(100994563, 8691, 14280, 20320445);
 
 		callWinRate(mocks.createMessage(null, 'bigguy20 [CL]'), {
 			account_id: 100994563
 		}).then(result => {
 			st.deepEqual(result, {
-				sentMsg: '@bigguy20 [CL], You have won 8691 of 14280 battles. That is 60.86% victory!',
+				sentMsg: '@bigguy20 [CL], You have won 8691 of 14280 battles. That is 60.86% victory! Your average damage is 1423.00.',
 				updateFields: {
 					wins: 8691,
-					battles: 14280
+					battles: 14280,
+					damage: 20320445
 				}
 			}, 'verify response and record update');
 
@@ -420,7 +427,7 @@ test('command.winRate.winRate', t => {
 	});
 
 	t.test('follow up call, no additional battles', st => {
-		const accountInfo = accountInfoMock(100994564, 7682, 18290);
+		const accountInfo = accountInfoMock(100994564, 7682, 18290, 18290000);
 
 		callWinRate(mocks.createMessage(null, 'littleguy21 [CL]'), {
 			account_id: 100994564,
@@ -428,7 +435,7 @@ test('command.winRate.winRate', t => {
 			battles: 18290
 		}).then(result => {
 			st.deepEqual(result, {
-				sentMsg: '@littleguy21 [CL], You have won 7682 of 18290 battles. That is 42.00% victory!'
+				sentMsg: '@littleguy21 [CL], You have won 7682 of 18290 battles. That is 42.00% victory! Your average damage is 1000.00.'
 			}, 'verify response');
 
 			st.ok(accountInfo.isDone(), 'made one API call');
@@ -440,22 +447,24 @@ test('command.winRate.winRate', t => {
 	});
 
 	t.test('follow up call, one additional battle', st => {
-		const accountInfo = accountInfoMock(100994565, 9260, 13933);
+		const accountInfo = accountInfoMock(100994565, 9260, 13933, 13933000);
 
 		callWinRate(mocks.createMessage(null, 'biggirl22 [CL]'), {
 			account_id: 100994565,
 			wins: 9259,
-			battles: 13932
+			battles: 13932,
+			damage: 13931164
 		}).then(result => {
 			st.deepEqual(result, {
 				sentMsg: [
-					'@biggirl22 [CL], You have won 9260 of 13933 battles. That is 66.46% victory!',
-					'Last time you asked was 1 battles ago, at 66.46% victory.',
-					'Over those 1 battles, you won 100.00%!'
+					'@biggirl22 [CL], You have won 9260 of 13933 battles. That is 66.46% victory! Your average damage is 1000.00.',
+					'Last time you asked was 1 battles ago, at 66.46% victory and 999.94 average damage dealt.',
+					'Over those 1 battles, you won 100.00% with average damage of 1836.00!'
 				].join('\n'),
 				updateFields: {
 					wins: 9260,
-					battles: 13933
+					battles: 13933,
+					damage: 13933000
 				}
 			}, 'verify response and record update');
 
@@ -468,22 +477,53 @@ test('command.winRate.winRate', t => {
 	});
 
 	t.test('follow up call, several additional battles', st => {
-		const accountInfo = accountInfoMock(100994566, 5003, 11502);
+		const accountInfo = accountInfoMock(100994566, 5003, 11502, 9836625);
 
 		callWinRate(mocks.createMessage(null, 'littlegirl23 [CL]'), {
+			account_id: 100994566,
+			wins: 4992,
+			battles: 11483,
+			damage: 9822276
+		}).then(result => {
+			st.deepEqual(result, {
+				sentMsg: [
+					'@littlegirl23 [CL], You have won 5003 of 11502 battles. That is 43.50% victory! Your average damage is 855.21.',
+					'Last time you asked was 19 battles ago, at 43.47% victory and 855.38 average damage dealt.',
+					'Over those 19 battles, you won 57.89% with average damage of 755.21!'
+				].join('\n'),
+				updateFields: {
+					wins: 5003,
+					battles: 11502,
+					damage: 9836625
+				}
+			}, 'verify response and record update');
+
+			st.ok(accountInfo.isDone(), 'made one API call');
+			st.end();
+		}, error => {
+			st.fail(error);
+			st.end();
+		});
+	});
+
+	t.test('Check average damage for the first time', st => {
+		const accountInfo = accountInfoMock(100994566, 5000, 11501, 11501000);
+
+		callWinRate(mocks.createMessage(null, 'tankgrl [CL]'), {
 			account_id: 100994566,
 			wins: 4992,
 			battles: 11483
 		}).then(result => {
 			st.deepEqual(result, {
 				sentMsg: [
-					'@littlegirl23 [CL], You have won 5003 of 11502 battles. That is 43.50% victory!',
-					'Last time you asked was 19 battles ago, at 43.47% victory.',
-					'Over those 19 battles, you won 57.89%!'
+					'@tankgrl [CL], You have won 5000 of 11501 battles. That is 43.47% victory! Your average damage is 1000.00.',
+					'Last time you asked was 18 battles ago, at 43.47% victory.',
+					'Over those 18 battles, you won 44.44%!'
 				].join('\n'),
 				updateFields: {
-					wins: 5003,
-					battles: 11502
+					wins: 5000,
+					battles: 11501,
+					damage: 11501000
 				}
 			}, 'verify response and record update');
 

--- a/test/lib.command.winRate.js
+++ b/test/lib.command.winRate.js
@@ -11,15 +11,6 @@ const dbInstance = new Datastore({
 });
 const callTankWinRate = wr.tankWinRate.fn.bind(Object.assign(mocks.commands, {db: dbInstance}));
 const callWinRate = wr.winRate.fn.bind(mocks.commands);
-const callFormatNumber = wr.formatNumber;
-
-test('numberFormat', t => {
-	t.equal(callFormatNumber(1500), '1,500');
-	t.equal(callFormatNumber(26522.56723), '26,522.57');
-	t.equal(callFormatNumber(340.500), '340.5');
-	t.equal(callFormatNumber(2362244.0000000000002), '2,362,244');
-	t.end();
-});
 
 test('command.winRate.tankWinRate', t => {
 	t.deepEqual(wr.tankWinRate.fn.options, {

--- a/test/lib.helpers.js
+++ b/test/lib.helpers.js
@@ -98,3 +98,11 @@ test('helpers.messageToString', t => {
 
 	t.end();
 });
+
+test('helpers.numberFormat', t => {
+	t.equal(helpers.formatNumber(1500), '1,500');
+	t.equal(helpers.formatNumber(26522.56723), '26,522.57');
+	t.equal(helpers.formatNumber(340.500), '340.5');
+	t.equal(helpers.formatNumber(2362244.0000000000002), '2,362,244');
+	t.end();
+});


### PR DESCRIPTION
The tank-win-rate and win-rate commands now add your average damage stats. If there are no recorded damage stats (as will be the case with everyone at first) then that part of the message is omitted.